### PR TITLE
Fixes for CIF file handling

### DIFF
--- a/R/cif.R
+++ b/R/cif.R
@@ -24,6 +24,7 @@
 readCIF <- function(filename, message=FALSE){
   f <- file(filename)
   lcif <- readLines(f,warn=FALSE)
+  if (tail(lcif, 1) != "") lcif <- c(lcif, "")
   l_list <- grep("loop_",lcif)
   l_list1 <- append(l_list,length(lcif))
   mat<-zoo::rollapply(l_list1, 2,stack)

--- a/R/cif.R
+++ b/R/cif.R
@@ -25,6 +25,7 @@ readCIF <- function(filename, message=FALSE){
   f <- file(filename)
   lcif <- readLines(f,warn=FALSE)
   if (tail(lcif, 1) != "") lcif <- c(lcif, "")
+  lcif <- gsub("^[ \t]*" ,"", lcif)
   l_list <- grep("loop_",lcif)
   l_list1 <- append(l_list,length(lcif))
   mat<-zoo::rollapply(l_list1, 2,stack)


### PR DESCRIPTION
This pull request fixes two bugs related to the handling of CIF files.

These bugs were reported in the following issues: https://github.com/jfoadi/cry/issues/3, https://github.com/jfoadi/cry/issues/4

The first bug was that the number of reading regions was different from the expected number when the file did not end with LF LF.
The second bug was that readCIF did not correctly read CIF files that contain leading space characters.
The changes have been tested and are ready to be merged.
